### PR TITLE
Updated: code to remove the module registration on-demand and removed…

### DIFF
--- a/components/Dropin.vue
+++ b/components/Dropin.vue
@@ -17,12 +17,6 @@ export default {
       locale: storeView.i18n.defaultLocale.replace('-', '_') // Convert to PayPal format of locale
     }
   },
-<<<<<<< HEAD
-=======
-  // created () {
-  //   registerModule(Braintree)
-  // },
->>>>>>> e0314a129c4bb47ac7c2c3802bfb8f4b5d7797ef
   mounted () {
     this.configureBraintree()
   },
@@ -52,12 +46,9 @@ export default {
             console.error(err)
             return;
           }
-<<<<<<< HEAD
           dropinInstance.on('paymentOptionSelected', function(event) {
             button.removeAttribute('disabled')
           })
-=======
->>>>>>> e0314a129c4bb47ac7c2c3802bfb8f4b5d7797ef
           button.addEventListener('click', () => {
             dropinInstance.requestPaymentMethod((err, payload) => {
               if (!err) {
@@ -68,16 +59,10 @@ export default {
                 // when payment made through 'paypal through braintree' update payment method to 'braintree_paypal'
                 if (payload.type === 'PayPalAccount') {
                   self.$store.state.checkout.paymentDetails.paymentMethod = 'braintree_paypal'
-<<<<<<< HEAD
                 } else {
                   self.$store.state.checkout.paymentDetails.paymentMethod = 'braintree'
                 }
                 this.$emit('sendDataToCheckout')
-=======
-                } else if (payload.type === 'CreditCard') {
-                  self.$store.state.checkout.paymentDetails.paymentMethod = 'braintreecreditcard'
-                }
->>>>>>> e0314a129c4bb47ac7c2c3802bfb8f4b5d7797ef
               } else {
                 console.error(err)
               }

--- a/components/Dropin.vue
+++ b/components/Dropin.vue
@@ -46,9 +46,6 @@ export default {
             console.error(err)
             return;
           }
-          dropinInstance.on('paymentOptionSelected', function(event) {
-            button.removeAttribute('disabled')
-          })
           button.addEventListener('click', () => {
             dropinInstance.requestPaymentMethod((err, payload) => {
               if (!err) {
@@ -62,12 +59,25 @@ export default {
                 } else {
                   self.$store.state.checkout.paymentDetails.paymentMethod = 'braintree'
                 }
-                this.$emit('sendDataToCheckout')
+                setTimeout(() => {
+                  this.$emit('sendDataToCheckout')
+                }, 1000)
               } else {
                 console.error(err)
               }
             })
           })
+          if (dropinInstance.isPaymentMethodRequestable()) {
+            button.removeAttribute('disabled');
+          }
+
+          dropinInstance.on('paymentMethodRequestable', function (event) {
+            button.removeAttribute('disabled');
+          });
+
+          dropinInstance.on('noPaymentMethodRequestable', function () {
+            button.setAttribute('disabled', true);
+          });
         })
       })
     },

--- a/index.ts
+++ b/index.ts
@@ -16,19 +16,5 @@ export const Braintree: StorefrontModule = function ({ app, store }) {
       'default': true,
       'offline': false
     })
-
-    if (!app.$isServer) {
-      let isCurrentPaymentMethod = false
-      store.watch((state) => state.checkout.paymentDetails, (prevMethodCode, newMethodCode) => {
-        isCurrentPaymentMethod = newMethodCode.paymentMethod === CURRENT_METHOD_CODE
-      })
-
-      const invokePlaceOrder = () => {
-        if (isCurrentPaymentMethod) {
-          app.$emit('checkout-do-placeOrder', {})
-        }
-      }
-      app.$on('checkout-before-placeOrder', invokePlaceOrder)
-    }
   })
 }

--- a/patches/BrainTree.patch
+++ b/patches/BrainTree.patch
@@ -1,0 +1,36 @@
+diff --git src/themes/notnaked/components/organisms/o-confirm-order.vue src/themes/notnaked/components/organisms/o-confirm-order.vue
+index ade79c37..6fc057af 100644
+--- src/themes/notnaked/components/organisms/o-confirm-order.vue
++++ src/themes/notnaked/components/organisms/o-confirm-order.vue
+@@ -279,9 +279,12 @@
+       </div>
+       <MPriceSummary class="totals__element" />
+     </div>
++    <div class="payment">
++      <braintree-dropin v-if="paymentMethod === 'Braintree'"/>
++    </div>
+     <div class="actions">
+       <SfButton
+-        class="sf-button--full-width actions__button"
++        class="sf-button--full-width actions__button place-order-btn"
+         :disabled="$v.orderReview.$invalid || !productsInCart.length"
+         @click="placeOrder"
+       >
+@@ -319,6 +322,7 @@ import MPriceSummary from 'theme/components/molecules/m-price-summary';
+ import APromoCode from 'theme/components/atoms/a-promo-code';
+ import { ModalList } from 'theme/store/ui/modals'
+ import { createSmoothscroll } from 'theme/helpers';
++import BraintreeDropin from 'src/modules/payment-braintree/components/Dropin'
+ 
+ export default {
+   name: 'OConfirmOrder',
+@@ -334,7 +338,8 @@ export default {
+     SfCharacteristic,
+     SfCollectedProduct,
+     APromoCode,
+-    MPriceSummary
++    MPriceSummary,
++    BraintreeDropin
+   },
+   mixins: [OrderReview],
+   data () {


### PR DESCRIPTION
… the code to place an order after the payment completes(#1dbx82)


1. Removed the module registration on-demand, because we are using `coreHooks.afterAppInit` to add payment method which only fires after app initialization, so removed the on-demand registration and using the normal module registration.
2. Removed the code to emit the events used for placing an order.
3. Using callbacks for handling the events.
4. Added some checks for handling the enabling and disabling the button for all the cases.